### PR TITLE
feat: local dev server + auto-detect UI endpoint + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     # Remove the heavy pip install to avoid resolver issues and speed up CI
 
     - name: Configure AWS Credentials (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -44,14 +44,14 @@ jobs:
       working-directory: ./backend/infra
 
     - name: Terraform Plan (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
       id: plan
       run: terraform plan -no-color
       working-directory: ./backend/infra
       continue-on-error: true
 
     - name: Terraform Apply (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
       run: terraform apply -auto-approve -input=false
       working-directory: ./backend/infra
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     # Remove the heavy pip install to avoid resolver issues and speed up CI
 
     - name: Configure AWS Credentials (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -44,14 +44,14 @@ jobs:
       working-directory: ./backend/infra
 
     - name: Terraform Plan (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       id: plan
       run: terraform plan -no-color
       working-directory: ./backend/infra
       continue-on-error: true
 
     - name: Terraform Apply (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: terraform apply -auto-approve -input=false
       working-directory: ./backend/infra
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
     # Python setup and full dependency install are unnecessary for Terraform-only deploys
     # Remove the heavy pip install to avoid resolver issues and speed up CI
 
-    - name: Configure AWS Credentials
+    - name: Configure AWS Credentials (deploy only)
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -42,14 +43,15 @@ jobs:
       run: terraform validate -no-color
       working-directory: ./backend/infra
 
-    - name: Terraform Plan
+    - name: Terraform Plan (deploy only)
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
       id: plan
       run: terraform plan -no-color
       working-directory: ./backend/infra
       continue-on-error: true
 
-    - name: Terraform Apply
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    - name: Terraform Apply (deploy only)
+      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
       run: terraform apply -auto-approve -input=false
       working-directory: ./backend/infra
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
     # Remove the heavy pip install to avoid resolver issues and speed up CI
 
     - name: Build Lambda layer artifact
+      working-directory: backend/lambda_layers
       shell: bash
       run: |
-        chmod +x backend/lambda_layers/build_layers.sh
-        PY_CMD=python3 backend/lambda_layers/build_layers.sh
+        chmod +x build_layers.sh
+        PY_CMD=python3 ./build_layers.sh
 
     - name: Compute deploy guard (upstream main with AWS keys)
       id: deploy_guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r backend/requirements.txt
+    # Python setup and full dependency install are unnecessary for Terraform-only deploys
+    # Remove the heavy pip install to avoid resolver issues and speed up CI
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
     # Python setup and full dependency install are unnecessary for Terraform-only deploys
     # Remove the heavy pip install to avoid resolver issues and speed up CI
 
+    - name: Build Lambda layer artifact
+      shell: bash
+      run: |
+        chmod +x backend/lambda_layers/build_layers.sh
+        PY_CMD=python3 backend/lambda_layers/build_layers.sh
+
     - name: Compute deploy guard (upstream main with AWS keys)
       id: deploy_guard
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,25 @@ jobs:
     # Python setup and full dependency install are unnecessary for Terraform-only deploys
     # Remove the heavy pip install to avoid resolver issues and speed up CI
 
+    - name: Compute deploy guard (upstream main with AWS keys)
+      id: deploy_guard
+      shell: bash
+      env:
+        REPO: ${{ github.repository }}
+        REF: ${{ github.ref }}
+        EVENT: ${{ github.event_name }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: |
+        can_deploy=false
+        if [[ "$REPO" == "ModelEarth/codechat" && "$EVENT" == "push" && "$REF" == "refs/heads/main" \
+              && -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]]; then
+          can_deploy=true
+        fi
+        echo "deploy=$can_deploy" >> "$GITHUB_OUTPUT"
+
     - name: Configure AWS Credentials (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ steps.deploy_guard.outputs.deploy == 'true' }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -44,14 +61,14 @@ jobs:
       working-directory: ./backend/infra
 
     - name: Terraform Plan (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ steps.deploy_guard.outputs.deploy == 'true' }}
       id: plan
       run: terraform plan -no-color
       working-directory: ./backend/infra
       continue-on-error: true
 
     - name: Terraform Apply (deploy only)
-      if: ${{ github.repository == 'ModelEarth/codechat' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ steps.deploy_guard.outputs.deploy == 'true' }}
       run: terraform apply -auto-approve -input=false
       working-directory: ./backend/infra
       env:

--- a/README.md
+++ b/README.md
@@ -421,6 +421,16 @@ API_URL=$(terraform output -raw api_gateway_url)
 echo "window.CODECHAT_API_ENDPOINT = '$API_URL';" >> ../../chat/script.js
 ```
 
+
+#### Local Backend (Dev Server)
+```bash
+conda run -n model-earth-codechat python scripts/dev_server.py --mock
+```
+
+- Default binds to http://127.0.0.1:8080; update the chat UI endpoint to this value while testing.
+- Omit --mock to invoke real services when your OpenAI/Pinecone keys are present in the environment or .env file.
+
+
 ### Configuration Management
 
 #### Repository Configuration (`config/modelearth_repos.yml`)

--- a/scripts/dev_server.py
+++ b/scripts/dev_server.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Simple local dev server that reuses the deployed Lambda handlers.
+
+Exposes two routes matching the AWS API Gateway configuration:
+
+    - POST /query         -> src.lambdas.query_handler.index.lambda_handler
+    - GET  /repositories  -> src.lambdas.get_repositories.index.lambda_handler
+
+This lets you exercise the backend locally without provisioning AWS resources.
+The server relies on Flask (already listed in requirements.txt).
+
+Usage examples:
+
+    # Run on default port (8080) and load .env if present
+    python scripts/dev_server.py
+
+    # Force mock responses by clearing API keys
+    python scripts/dev_server.py --mock
+
+    # Bind to a different host/port and skip loading .env
+    python scripts/dev_server.py --host 0.0.0.0 --port 3000 --no-dotenv
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+from flask import Flask, Response, jsonify, request
+from flask_cors import CORS
+
+try:  # Optional dependency; skip silently if missing
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - python-dotenv is optional
+    load_dotenv = None  # type: ignore[assignment]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUERY_HANDLER_DIR = REPO_ROOT / "src" / "lambdas" / "query_handler"
+
+for path in (QUERY_HANDLER_DIR, REPO_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+
+from src.lambdas.get_repositories.index import (  # noqa: E402
+    lambda_handler as repositories_handler,
+)
+from src.lambdas.query_handler.index import (  # noqa: E402
+    lambda_handler as query_handler,
+)
+
+
+LOGGER = logging.getLogger("dev_server")
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(levelname)s] %(message)s",
+    )
+
+
+def _load_dotenv_if_available(use_dotenv: bool) -> None:
+    if not use_dotenv:
+        LOGGER.info("Skipping .env loading")
+        return
+    if load_dotenv is None:
+        LOGGER.info("python-dotenv not installed; skipping .env loading")
+        return
+    env_path = REPO_ROOT / ".env"
+    if env_path.exists():
+        LOGGER.info("Loading environment variables from %s", env_path)
+        load_dotenv(env_path, override=False)
+    else:
+        LOGGER.info("No .env file found at %s", env_path)
+
+
+def _apply_mock_mode(mock: bool) -> None:
+    if not mock:
+        return
+    LOGGER.info("Mock mode enabled: clearing OpenAI/Pinecone keys to trigger fallback responses")
+    for key in ("OPENAI_API_KEY", "PINECONE_API_KEY"):
+        os.environ.pop(key, None)
+    os.environ.setdefault("DEVSERVER_MOCK_MODE", "1")
+
+
+def _call_lambda(handler: Callable[[Dict[str, Any], Any], Dict[str, Any]], event: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        return handler(event, None)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.exception("Lambda handler raised an exception")
+        return {
+            "statusCode": 500,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"error": f"Lambda error: {exc}"}),
+        }
+
+
+def _flask_response(lambda_response: Dict[str, Any]) -> Response:
+    status = int(lambda_response.get("statusCode", 200))
+    headers = lambda_response.get("headers") or {}
+    body = lambda_response.get("body", "")
+    if not isinstance(body, (str, bytes)):
+        body = json.dumps(body)
+    return Response(response=body, status=status, headers=headers)
+
+
+def create_app(mock: bool = False) -> Flask:
+    app = Flask(__name__)
+    CORS(app)
+
+    @app.route("/health", methods=["GET"])
+    def health() -> Response:
+        return jsonify({"status": "ok", "mock": mock})
+
+    @app.route("/repositories", methods=["GET", "OPTIONS"])
+    def repositories() -> Response:
+        event = {
+            "httpMethod": request.method,
+            "headers": dict(request.headers),
+            "queryStringParameters": request.args.to_dict(flat=True),
+        }
+        lambda_response = _call_lambda(repositories_handler, event)
+        return _flask_response(lambda_response)
+
+    @app.route("/query", methods=["POST", "OPTIONS"])
+    def query() -> Response:
+        if request.method == "OPTIONS":
+            event_body: Any = None
+        else:
+            event_body = request.get_data(as_text=True)
+        event = {
+            "httpMethod": request.method,
+            "headers": dict(request.headers),
+            "body": event_body,
+        }
+        lambda_response = _call_lambda(query_handler, event)
+        return _flask_response(lambda_response)
+
+    return app
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the CodeChat backend locally")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8080, help="Port to bind (default: 8080)")
+    parser.add_argument("--mock", action="store_true", help="Force mock responses by clearing API keys")
+    parser.add_argument("--no-dotenv", action="store_true", help="Skip loading .env from the repo root")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_logging()
+    args = parse_args(argv)
+
+    _load_dotenv_if_available(use_dotenv=not args.no_dotenv)
+
+    _apply_mock_mode(args.mock)
+
+    app = create_app(mock=args.mock)
+    LOGGER.info("Starting dev server on http://%s:%d (mock=%s)", args.host, args.port, args.mock)
+    app.run(host=args.host, port=args.port, debug=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿Title: feat: local dev server + auto-detect UI endpoint + CI guard

Summary
- Add scripts/dev_server.py: Flask adapter to run the existing Lambda handlers locally (no AWS needed) with routes GET /repositories and POST /query. Supports optional .env loading and a --mock flag (forces handler fallback when keys are absent).
- Update chat/script.js: auto-detect API base and add safe overrides.
  - Local: http://127.0.0.1:8080
  - Production: same-origin /codechat/api (avoids CORS)
  - Overrides: window.CODECHAT_API_ENDPOINT, ?api= query param, and setCodeChatApiEndpoint()/clearCodeChatApiEndpoint() helpers.
  - New helpers: resolveApiEndpoint, normalizeEndpoint (accepts only absolute http(s) URLs), buildApiUrl (prevents double slashes).
- CI hardening (fork-friendly):
  - Removed unnecessary Python dependency install (pip -r backend/requirements.txt). Terraform-only deploy doesn’t need it and it previously caused resolver failures on Ubuntu runners.
  - Build the Lambda layer zip before Terraform validate (runs backend/lambda_layers/build_layers.sh with PY_CMD=python3 from its directory).
  - Guard AWS deploy steps so they run only on upstream ModelEarth/codechat main and only when AWS keys exist (AWS_ACCESS_KEY_ID/SECRET).
  - Keep checkout + setup-terraform + terraform init/validate on all repos/PRs for fast feedback without requiring secrets.

Details
- UI
  - Endpoint selection now happens once at startup, then all requests use buildApiUrl('/repositories') and buildApiUrl('/query').
  - Error messages guide how to set the endpoint at runtime via setCodeChatApiEndpoint().
  - Placeholders/relative paths are ignored by normalizeEndpoint to avoid accidental bad bases from config.
- Dev server
  - Imports the existing Lambda handlers (src/lambdas/get_repositories/index.py and src/lambdas/query_handler/index.py) and calls lambda_handler(event, None).
  - --mock clears OPENAI_API_KEY/PINECONE_API_KEY to exercise handler fallback without any external calls.
  - CORS enabled for localhost convenience.
- CI
  - New step "Build Lambda layer artifact": runs the provided build_layers.sh so the zip exists for filebase64sha256 in Terraform.
  - New conditional guard implemented via environment evaluation; downstream steps (configure-aws-credentials, terraform plan/apply) use if: steps.deploy_guard.outputs.deploy == 'true'.

Why
- Local dev (UI+backend) should work without AWS; dev_server.py unlocks that.
- The UI should not require manual edits to point at local/prod; auto-detection plus small override helpers keeps it flexible and safe.
- CI should succeed on forks while still deploying from upstream when secrets are present; guards + artifact build address both.

How to test
- Local backend: conda run -n model-earth-codechat python scripts/dev_server.py  (add --mock to force fallback)
- Local UI: conda run -n model-earth-codechat python -m http.server 8887 --directory chat
- Open http://127.0.0.1:8887/
  - Repos dropdown loads (GET 127.0.0.1:8080/repositories)
  - Send a message (POST 127.0.0.1:8080/query)
  - setCodeChatApiEndpoint('http://127.0.0.1:8080') / clearCodeChatApiEndpoint() update the base immediately
- CI: On forks, Actions should run checkout → setup-terraform → init/validate and skip deploy; on upstream main with AWS keys, build layer → credentials → plan/apply proceed as before.

Backward compatibility
- UI keeps accepting window.CODECHAT_API_ENDPOINT if provided; new logic only adds safer defaults and better normalization.
- No backend handler changes; dev server is additive.
- Terraform unchanged; CI ensures the expected layer file exists before validate.

Risks / Rollback
- UI: rollback is a single file (chat/script.js) if needed.
- CI: rollback is a single file (.github/workflows/ci.yml).

Notes
- No secrets or URLs are committed. All deploy-related steps require repo secrets; PRs/branches on forks will not attempt deploy.
